### PR TITLE
test: e2e-Übersicht-Helper robust gegen Mehr-Wochen-Akkordeon (Sonntags-Bug)

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -135,14 +135,24 @@ export async function expandWeekUntilVisible(
   panel: ReturnType<Page["locator"]>,
 ): Promise<void> {
   await expect(page.locator("#accordion")).toBeVisible({ timeout: 15_000 });
+  // Only the week cards' OWN headers — not the assignment-panel headers nested
+  // inside an expanded week (they also carry .card-header). Matching those too
+  // shifts nth() indexing the moment a week opens, and clicking an already-open
+  // week header would re-collapse it. This bit specifically when the target
+  // assignment sits in a different ISO week than week one (e.g. a "tomorrow"
+  // default-dated assignment created on a Sunday).
+  const weekHeaders = page.locator("#accordion > .card > .card-header");
   for (let round = 0; round < 10; round++) {
     if (await panel.isVisible()) return;
-    const headings = page.locator("#accordion .card-header");
-    const count = await headings.count();
+    const count = await weekHeaders.count();
     for (let i = 0; i < count; i++) {
       if (await panel.isVisible()) return;
-      await headings.nth(i).click();
-      await page.waitForTimeout(400);
+      const header = weekHeaders.nth(i);
+      // Expand collapsed weeks only (chevron points right); never re-collapse.
+      if ((await header.locator("i.fa-chevron-circle-right").count()) > 0) {
+        await header.click();
+        await page.waitForTimeout(400);
+      }
     }
     await page.waitForTimeout(500);
   }


### PR DESCRIPTION
## Problem

Beim Lauf der E2E-Suite gegen den Docker-Stack fielen heute (Sonntag) **4 Tests** aus — 03, 04, 05, 10 — alle an derselben Stelle: `expandWeekUntilVisible` (helpers.ts). **Kein App-Bug**: die Übersicht funktioniert manuell einwandfrei (Akkordeon klappt auf, Panels rendern, keine Konsolenfehler); 22/26 grün.

## Ursache (datumsabhängig, nicht Docker-spezifisch)

- Der Seed-Termin hat `start = new Date()` → **heute**.
- Neu erstellte Termine haben Default-Start `moment().add(1,'days').hour(12)` → **morgen**.
- Nur an einem **Sonntag** liegen *heute* und *morgen* in verschiedenen ISO-Wochen → die Übersicht zeigt **zwei** Wochen-Akkordeons.

Der Helper matchte mit `#accordion .card-header` aber auch die **Panel-Header innerhalb** einer aufgeklappten Woche. Sobald Woche 1 öffnet, verschiebt das die `nth()`-Indizierung, und ein erneuter Klick auf einen bereits offenen Wochen-Header klappt ihn wieder zu → der Termin in Woche 2 wird nie sichtbar → 120s-Timeout. Dieselbe Suite wäre heute auch gegen den Dev-Server rot gelaufen.

## Fix

Nur die echten Wochen-Header ansteuern (`#accordion > .card > .card-header`, direkte Kinder) und ausschließlich **eingeklappte** Wochen aufklappen (Chevron zeigt nach rechts) — nie eine offene Woche wieder zuklappen.

## Verifikation

Gegen den Docker-Stack, frische DB, **an einem Sonntag**: vorher 4 rot → **jetzt 26/26 grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWA2tWPmqEDGHZSP7r2uGd