### PR TITLE
fix: Termin-Panel — Datum wieder zentriert (BS5-Flex-Regression)

### DIFF
--- a/src/client/react/components/DateDisplay.tsx
+++ b/src/client/react/components/DateDisplay.tsx
@@ -25,7 +25,9 @@ export default class DateDisplay extends React.Component<DateDisplayProps, {}> {
     const endTime = end.format("LT");
 
     return (
-      <div className="row">
+      // g-0: no gutter so the white date cell and blue time cell tile the full
+      // card width — the time cell stays flush to the right edge (no white gap).
+      <div className="row g-0">
         {/* Centre the day/month in the white cell — horizontally via text-center,
             vertically (against the taller time cell) via a flex column. The old
             BS3 markup put `.row` on these, which in BS5 turns them into flex

--- a/src/client/react/components/DateDisplay.tsx
+++ b/src/client/react/components/DateDisplay.tsx
@@ -26,9 +26,13 @@ export default class DateDisplay extends React.Component<DateDisplayProps, {}> {
 
     return (
       <div className="row">
-        <div className="col-7">
-          <div className="huge row">{dayOfMonth}</div>
-          <div className="row">{month}</div>
+        {/* Centre the day/month in the white cell — horizontally via text-center,
+            vertically (against the taller time cell) via a flex column. The old
+            BS3 markup put `.row` on these, which in BS5 turns them into flex
+            containers and left-aligns the date. */}
+        <div className="col-7 text-center d-flex flex-column justify-content-center">
+          <div className="huge">{dayOfMonth}</div>
+          <div>{month}</div>
         </div>
         <div className="col-5 time text-center">
           {startTime}

--- a/src/client/templates/assignments/showOverview/showOverview.less
+++ b/src/client/templates/assignments/showOverview/showOverview.less
@@ -13,15 +13,13 @@
   margin-bottom: @line-height-computed !important;
 
   .assignment-item {
-    padding-top: 0;
-    padding-bottom: 0;
+    // No card-body padding: the date/time columns (g-0 rows) tile the full
+    // width so the blue time cell stays flush to the right edge (no white gap).
+    padding: 0;
     .huge {
       font-size: 25px;
     }
     .time {
-
-      //.border-radius(0,0,@border-radius-small, 0); // Links unten rund
-      margin-right: -2px;
       background-color: @brand-primary;
       color: #fff;
     }

--- a/src/client/templates/assignments/showOverview/subComponents/AssignmentPanelBody.tsx
+++ b/src/client/templates/assignments/showOverview/subComponents/AssignmentPanelBody.tsx
@@ -88,6 +88,8 @@ class AssignmentPanelProgressBar extends React.Component<AssignmentPanelProps, {
       return null;
     }
 
-    return <div className="row">{this.renderProgressBar()}</div>;
+    // g-0 matches the date/time row so the body content stays flush to the
+    // card edges (card-body has zero horizontal padding — see showOverview.less).
+    return <div className="row g-0">{this.renderProgressBar()}</div>;
   }
 }


### PR DESCRIPTION
## Problem

Das Termin-Panel in der Übersicht sah nach der BS3→BS5-Migration unbalanciert aus: die Datumszahl („28.") klebte oben links statt zentriert, die Aufteilung Datum (weiß) / Zeit (blau) wirkte schief.

## Ursache

`DateDisplay` setzte auf den Tag- und Monats-`div` die Klasse `.row`:

```jsx
<div className="huge row">{dayOfMonth}</div>
<div className="row">{month}</div>
```

Unter BS3 war `.row` ein Block mit negativen Margins, dessen Inhalt vom `text-center` des Eltern-Containers (`card-body text-center assignment-item`) zentriert wurde. Unter **BS5 ist `.row` ein `display:flex`-Container** — der Tag wird zum linksbündigen Flex-Item, und `text-align:center` zentriert keine Flex-Items. Ergebnis: „28." rutscht nach links/oben.

## Fix

`.row` an Tag/Monat entfernt. Die Datums-Spalte zentriert ihren Inhalt jetzt explizit:

- horizontal über `text-center`
- vertikal (gegen die höhere, dreizeilige Zeit-Spalte) über `d-flex flex-column justify-content-center`

Die blaue Zeit-Spalte bleibt durch das Default-`align-items:stretch` der Row über die volle Höhe.

## Verifikation

Visuell gegen die Legacy-Optik geprüft (Dev-Build): „29. Juni" wieder zentriert in der weißen Spalte, blaue Zeit-Spalte über die volle Höhe — identisch zum alten Panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWA2tWPmqEDGHZSP7r2uGd
