### PR TITLE
fix: Marken-Blau auf Prod-Ton #4A6DA7 angeglichen

### DIFF
--- a/src/client/lib/bootstrap5.import.less
+++ b/src/client/lib/bootstrap5.import.less
@@ -6,7 +6,7 @@
  */
 :root,
 [data-bs-theme=light] {
-  --bs-blue: #0d6efd;
+  --bs-blue: #4a6da7;
   --bs-indigo: #6610f2;
   --bs-purple: #6f42c1;
   --bs-pink: #d63384;
@@ -29,7 +29,7 @@
   --bs-gray-700: #495057;
   --bs-gray-800: #343a40;
   --bs-gray-900: #212529;
-  --bs-primary: #0d6efd;
+  --bs-primary: #4a6da7;
   --bs-secondary: #6c757d;
   --bs-success: #198754;
   --bs-info: #0dcaf0;
@@ -37,7 +37,7 @@
   --bs-danger: #dc3545;
   --bs-light: #f8f9fa;
   --bs-dark: #212529;
-  --bs-primary-rgb: 13, 110, 253;
+  --bs-primary-rgb: 74, 109, 167;
   --bs-secondary-rgb: 108, 117, 125;
   --bs-success-rgb: 25, 135, 84;
   --bs-info-rgb: 13, 202, 240;
@@ -45,7 +45,7 @@
   --bs-danger-rgb: 220, 53, 69;
   --bs-light-rgb: 248, 249, 250;
   --bs-dark-rgb: 33, 37, 41;
-  --bs-primary-text-emphasis: #052c65;
+  --bs-primary-text-emphasis: #1e2c43;
   --bs-secondary-text-emphasis: #2b2f32;
   --bs-success-text-emphasis: #0a3622;
   --bs-info-text-emphasis: #055160;
@@ -53,7 +53,7 @@
   --bs-danger-text-emphasis: #58151c;
   --bs-light-text-emphasis: #495057;
   --bs-dark-text-emphasis: #495057;
-  --bs-primary-bg-subtle: #cfe2ff;
+  --bs-primary-bg-subtle: #dbe2ed;
   --bs-secondary-bg-subtle: #e2e3e5;
   --bs-success-bg-subtle: #d1e7dd;
   --bs-info-bg-subtle: #cff4fc;
@@ -61,7 +61,7 @@
   --bs-danger-bg-subtle: #f8d7da;
   --bs-light-bg-subtle: #fcfcfd;
   --bs-dark-bg-subtle: #ced4da;
-  --bs-primary-border-subtle: #9ec5fe;
+  --bs-primary-border-subtle: #b7c5dc;
   --bs-secondary-border-subtle: #c4c8cb;
   --bs-success-border-subtle: #a3cfbb;
   --bs-info-border-subtle: #9eeaf9;
@@ -93,11 +93,11 @@
   --bs-tertiary-bg: #f8f9fa;
   --bs-tertiary-bg-rgb: 248, 249, 250;
   --bs-heading-color: inherit;
-  --bs-link-color: #0d6efd;
-  --bs-link-color-rgb: 13, 110, 253;
+  --bs-link-color: #4a6da7;
+  --bs-link-color-rgb: 74, 109, 167;
   --bs-link-decoration: underline;
-  --bs-link-hover-color: #0a58ca;
-  --bs-link-hover-color-rgb: 10, 88, 202;
+  --bs-link-hover-color: #3b5786;
+  --bs-link-hover-color-rgb: 59, 87, 134;
   --bs-code-color: #d63384;
   --bs-highlight-color: #212529;
   --bs-highlight-bg: #fff3cd;

--- a/src/client/lib/variables.less
+++ b/src/client/lib/variables.less
@@ -6,7 +6,10 @@
 @gray-light: lighten(#000, 60%);
 @gray-lighter: lighten(#000, 93.5%);
 @gray-lightest: lighten(#000, 97.25%);
-@brand-primary: #428bca;
+// Themed slate-blue (matches production / Color.BrandPrimary). The BS3 default
+// (#428bca) was brighter than the legacy SB-Admin theme — keep both the LESS
+// bridge and the BS5 --bs-primary on #4a6da7 so cards/buttons/links match.
+@brand-primary: #4a6da7;
 @brand-success: #5cb85c;
 @brand-info: #5bc0de;
 @brand-warning: #f0ad4e;


### PR DESCRIPTION
## Beobachtung (Vergleich Prod ↔ neu)

Direkter Vergleich von jw-public.org (Legacy/Prod) und der neuen Version, gemessene Karten-Hintergründe:

| | blaue Karte | Links / BS5 |
|---|---|---|
| **Prod** | `rgb(74,109,167)` = **#4A6DA7** (gedämpftes Slate-Blau) | #4A6DA7 |
| **Neu (vorher)** | `rgb(66,139,202)` = **#428BCA** (BS3-Default, heller) | #0D6EFD (BS5-Default) |

Der Haupt-User-Flow (Dashboard → Karten → Terminansicht) ist identisch; der Unterschied war rein farblich.

## Ursache

Bei der BS3→BS5-Migration fiel das getönte Theme-Primärblau auf die Framework-Defaults zurück. Das Original #4A6DA7 lebte nur noch in `Color.ts` (`Color.BrandPrimary`, Kommentar „Ursprünglich: #337ab7"), während die CSS/LESS-Komponenten `@brand-primary: #428bca` (BS3) bzw. `--bs-primary: #0d6efd` (BS5) nutzten.

## Fix

Primärblau app-weit auf **#4A6DA7** vereinheitlicht (konsistent mit `Color.ts`):

- `variables.less`: `@brand-primary` → `#4a6da7` (Karten, Buttons, Panels über die BS3-Bridge)
- `bootstrap5.import.less`: `--bs-primary`/`-rgb`, `--bs-link-color`/`-rgb`, `--bs-link-hover-color`/`-rgb`, `--bs-blue` sowie die abgeleitete `primary-text-emphasis`/`bg-subtle`/`border-subtle`-Familie auf den #4A6DA7-Ton

Verifiziert: blaue Karte jetzt `rgb(74,109,167)` = #4A6DA7, identisch zu Prod; `--bs-primary`/`--bs-link-color` = #4a6da7.

## Hinweis Visual-Snapshots

Das Primärblau erscheint in mehreren Ansichten — die Linux-Snapshots (`00-visual`) ändern sich entsprechend und werden über den CI-Artefakt-Loop aktualisiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWA2tWPmqEDGHZSP7r2uGd
