### PR TITLE
fix: mobiles Menü, Termin-Balken-Abstufung, Versionslabel

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -164,6 +164,13 @@ jobs:
         run: cd src && meteor lint
       - run: cd src && meteor npm run compile
       - run: cd src && meteor npm test
+      # Versionslabel (Admin-Sidebar) mit dem Release-Tag bzw. Branch + Kurz-SHA
+      # stempeln, statt des Platzhalters "local #devBuild".
+      - name: Versionslabel stempeln
+        run: |
+          printf 'export const version = {\n  commit: "%s",\n  build: "%s",\n};\n' \
+            "${GITHUB_REF_NAME}" "${GITHUB_SHA::7}" > src/Version.ts
+          cat src/Version.ts
       - run: cd src && meteor build --allow-superuser ./build
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/src/client/lib/sb-admin-2.less
+++ b/src/client/lib/sb-admin-2.less
@@ -250,6 +250,19 @@ body {
   }
 }
 
+// Mobile: the topbar children (brand, top-links, hamburger) float, so the
+// sidebar — a static block here (the position:absolute above is desktop-only) —
+// must clear them onto its own full-width row. Without the clear the expanded
+// menu wraps into a narrow column beside the floated brand box (broken layout).
+// Collapsed by default; the hamburger's data-bs-toggle="collapse" reveals it.
+@media (max-width: @screen-xs-max) {
+  .sidebar {
+    clear: both;
+    float: none;
+    width: 100%;
+  }
+}
+
 // Buttons
 
 .btn-outline {

--- a/src/client/templates/assignments/showOverview/subComponents/AssignmentPanelBody.tsx
+++ b/src/client/templates/assignments/showOverview/subComponents/AssignmentPanelBody.tsx
@@ -75,10 +75,10 @@ class AssignmentPanelProgressBar extends React.Component<AssignmentPanelProps, {
         maxValue={usersWanted}
         backgroundColor={Color.GrayLighter}
         barColor={this.barColor()}
-        height="10px"
+        height="14px"
         wrapperClasses={this.progressBarWrapperClasses() ?? undefined}
-        striped={true}
-        active={true}
+        striped={false}
+        active={false}
       />
     );
   }


### PR DESCRIPTION
Drei UI-/Build-Fixes nach der Prod-Migration.

## Mobiles Menü (kaputt)
Die Topbar nutzt BS3-Floats (Brand links, Top-Links + Hamburger rechts). `.sidebar` ist auf Mobile ein statischer Block ohne `clear` — das ausgeklappte Menü fließt dadurch in einer schmalen Spalte **neben** dem gefloateten Brand-Kasten statt voll darunter. Fix: `@media (max-width: 767px)` → `.sidebar { clear:both; float:none; width:100% }`. Collapsed by default, Hamburger klappt auf (BS5 data-api).

## Termin-Balken zeigt diagonale Abstufung
Der Kapazitäts-Balken (`SmallProgressbar`) lief mit `striped={true} active={true}` → der diagonale `progress-bar-striped`-Gradient war bei 10px als „Abstufung" sichtbar. Fix: `striped/active=false` (solide Farbe) + Höhe 10px→14px.

## Versionslabel „local #devBuild"
`src/Version.ts` wurde nie beim Build gestempelt. Fix: Release-Job (`push`) schreibt vor `meteor build` Tag (`GITHUB_REF_NAME`) + Kurz-SHA hinein → z. B. „Version v2.1.0 #abc1234".

Hinweis: mobiles Rendering ließ sich in der Remote-Chrome-Umgebung nicht mit echter Mobile-Breite reproduzieren (Viewport blieb 1920) — daher CI-Validierung (compile/lint/build/e2e) vor dem Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)