### PR TITLE
feat: bearbeitete Termin-Zeile in der Terminverwaltung einfärben

### DIFF
--- a/src/client/templates/Group/ManageAssignments.less
+++ b/src/client/templates/Group/ManageAssignments.less
@@ -1,6 +1,16 @@
 @import "../../lib/variables.less";
 @import "../../lib/mixins.less";
 
+// Terminverwaltung: die Zeile, die gerade im "Daten ändern"-Formular offen ist,
+// deutlich einfärben (passend zum roten card-danger-Panel), damit klar ist,
+// welcher Termin gerade bearbeitet wird. BS5 stylt die generische .active-Klasse
+// auf <tr> nicht; erhöhte Spezifität überschreibt sicher das --bs-table-bg der
+// Zellen. Die Markierung wird beim Speichern/Schließen wieder entfernt.
+.table > tbody > tr.assignment-row-editing > td {
+  background-color: #f7dede;
+  transition: background-color 0.2s ease-in-out;
+}
+
 .user-entry-row {
   @border-color: @gray-lighter;
   @height: @input-height-base;

--- a/src/client/templates/Group/ManageAssignmentsComponent.tsx
+++ b/src/client/templates/Group/ManageAssignmentsComponent.tsx
@@ -147,6 +147,8 @@ export default function ManageAssignments(): JSX.Element {
       currentGroupId: groupId,
       panelClass: "card-danger",
       buttonClass: "btn-danger",
+      // Nach dem Speichern die Zeilen-Markierung wieder aufheben.
+      onSuccess: () => setSelectedId(null),
     };
     formKey = `update-${selectedAssignment._id}`;
   } else if (copiedAssignment) {
@@ -229,7 +231,7 @@ export default function ManageAssignments(): JSX.Element {
                     searchText={(a) => `${a.name} ${a.state} ${moment(a.start).format("L LT")}`}
                     defaultSort={{ column: 1, direction: "desc" }}
                     tableClassName="table table-responsive"
-                    rowClassName={(a) => (a._id === selectedId ? "active" : "")}
+                    rowClassName={(a) => (a._id === selectedId ? "assignment-row-editing" : "")}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Feature-Anfrage
Beim Bearbeiten eines Termins soll die Zeilen-Hintergrundfarbe wechseln, damit klar ist, welcher Termin gerade im Formular offen ist — und beim Speichern wieder zurücksetzen.

## Umsetzung
- `ManageAssignmentsComponent`: die bearbeitete Zeile bekommt die Klasse `assignment-row-editing` (statt der wirkungslosen `active` — BS5 stylt `.active` auf `<tr>` nicht).
- Neues `onSuccess: () => setSelectedId(null)` im Update-`formProps` → beim erfolgreichen Speichern wird die Markierung aufgehoben (ebenso beim erneuten Klick auf den Stift).
- `ManageAssignments.less`: dezentes Rot (`#f7dede`, passend zum roten „Daten ändern"-Panel) mit sanftem Übergang; erhöhte Spezifität überschreibt sicher `--bs-table-bg` der Zellen.

Live-Vorschau der Einfärbung (Regel injiziert) bestätigt die Optik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)