### PR TITLE
feat: Termin-Erinnerungen, iCal-Kalenderabo, Koordinator-Benachrichtigung bei Bewerbung

### DIFF
--- a/e2e/tests/15-calendar-and-application-notify.spec.ts
+++ b/e2e/tests/15-calendar-and-application-notify.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "@playwright/test";
+import {
+  login,
+  uniqueName,
+  flowGoto,
+  createAssignment,
+  expandWeekUntilVisible,
+  readStandardgruppeId,
+  registerUserInGroup,
+  clearMailbox,
+  findMail,
+} from "./helpers";
+
+// Top-3-Features: persönliches iCal-Kalenderabo (Profil) und die
+// Koordinator-Benachrichtigung bei neuen Bewerbungen. Die zeitgesteuerten
+// Termin-Erinnerungen sind unit-getestet (AssignmentReminder.test.ts) —
+// e2e wäre nur mit Zeitmanipulation sinnvoll.
+
+test.describe("Kalender-Abo (iCal)", () => {
+  test("profile provides a feed URL; applications show up; reset invalidates the old link", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const name = uniqueName("e2e-ical");
+
+    await login(page);
+    const { groupId, yearMonth } = await createAssignment(page, name);
+
+    // Auf den Termin bewerben -> erscheint als Bewerbung (TENTATIVE) im Feed.
+    await flowGoto(page, `/group/${groupId}/${yearMonth}/overview`);
+    const panel = page.locator("div.assignment-panel", { hasText: name });
+    await expandWeekUntilVisible(page, panel);
+    await panel.getByText("Bewerben").click();
+    await expect(panel.getByText("Bewerbung zurückziehen")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Kalender-Link im Profil erzeugen.
+    await page.goto("/my-profile");
+    await page.locator("button.show-calendar-url").click();
+    const urlInput = page.locator("input#calendarFeedUrl");
+    await expect(urlInput).toBeVisible({ timeout: 10_000 });
+    const feedUrl = await urlInput.inputValue();
+    expect(feedUrl).toMatch(/\/api\/calendar\/[a-f0-9]{40}\.ics$/);
+
+    // Feed abrufen: gültiges ICS mit der Bewerbung als TENTATIVE-Event.
+    const res = await page.request.get(feedUrl);
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("text/calendar");
+    const ics = await res.text();
+    expect(ics).toContain("BEGIN:VCALENDAR");
+    expect(ics).toContain(`Bewerbung: ${name}`);
+    expect(ics).toContain("STATUS:TENTATIVE");
+
+    // Link erneuern: neuer Token, alter Feed wird 404.
+    await page.locator("button.reset-calendar-url").click();
+    await page
+      .locator(".app-modal", { hasText: "Kalender-Link erneuern" })
+      .getByRole("button", { name: "Akzeptieren" })
+      .click();
+    await expect(urlInput).not.toHaveValue(feedUrl, { timeout: 10_000 });
+    const newFeedUrl = await urlInput.inputValue();
+    expect((await page.request.get(newFeedUrl)).status()).toBe(200);
+    expect((await page.request.get(feedUrl)).status()).toBe(404);
+  });
+});
+
+test.describe("Koordinator-Benachrichtigung bei Bewerbung", () => {
+  test("a member's application notifies the coordinator in-app and via email", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const name = uniqueName("e2e-applynotify");
+    const memberId = uniqueName("bewerberin");
+    const memberEmail = `${memberId}@example.org`;
+    const memberPassword = "test-passwort-123";
+
+    // Termin in der Standardgruppe anlegen (admin ist deren Koordinator).
+    const stdGroupId = await readStandardgruppeId(page);
+    await login(page);
+    const { yearMonth } = await createAssignment(page, name);
+    await page.goto("/logout");
+    await expect(page.locator("input#login")).toBeVisible();
+
+    // Neues Mitglied registrieren (pending) und vom Koordinator annehmen.
+    await registerUserInGroup(
+      page,
+      stdGroupId,
+      memberEmail,
+      memberPassword,
+      "Bianca",
+      "Bewerberin",
+    );
+    await page.goto("/logout");
+    await expect(page.locator("input#login")).toBeVisible();
+
+    await login(page);
+    await page.goto(`/group/${stdGroupId}/bewerber`);
+    const applicantRow = page.locator("tr", { hasText: memberEmail });
+    await expect(applicantRow).toBeVisible({ timeout: 15_000 });
+    await applicantRow.locator("button.accept-user").click();
+    await expect(page.locator("tr", { hasText: memberEmail })).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await page.goto("/logout");
+    await expect(page.locator("input#login")).toBeVisible();
+
+    // Als Mitglied auf den Termin bewerben.
+    await clearMailbox();
+    await login(page, memberEmail, memberPassword);
+    await flowGoto(page, `/group/${stdGroupId}/${yearMonth}/overview`);
+    const panel = page.locator("div.assignment-panel", { hasText: name });
+    await expandWeekUntilVisible(page, panel);
+    await panel.getByText("Bewerben").click();
+    await expect(panel.getByText("Bewerbung zurückziehen")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.goto("/logout");
+    await expect(page.locator("input#login")).toBeVisible();
+
+    // Koordinator sieht die In-App-Benachrichtigung ...
+    await login(page);
+    const dropdown = page.locator("#notificationsDropdown");
+    await expect(dropdown.locator(".badge-notify")).toBeVisible({
+      timeout: 15_000,
+    });
+    await dropdown.locator("a.dropdown-toggle").click();
+    await expect(dropdown.locator(".dropdown-menu")).toContainText(
+      "Neue Bewerbung",
+      {
+        timeout: 10_000,
+      },
+    );
+    await expect(dropdown.locator(".dropdown-menu")).toContainText("Bianca", {
+      timeout: 10_000,
+    });
+    await expect(dropdown.locator(".dropdown-menu")).toContainText(name, {
+      timeout: 10_000,
+    });
+    // aufräumen, damit Folge-Tests keine Alt-Benachrichtigungen sehen
+    await dropdown.locator("#removeAll").click();
+
+    // ... und bekommt die E-Mail.
+    const mail = await findMail(
+      (m) =>
+        m.Subject.includes(name) && /Bewerbung|application/i.test(m.Subject),
+      20_000,
+    );
+    expect(mail.Snippet).toContain("Bianca");
+  });
+});

--- a/src/client/templates/ModifyProfileComponent.tsx
+++ b/src/client/templates/ModifyProfileComponent.tsx
@@ -1,11 +1,13 @@
-import { alertDialog } from "../react/components/dialogs";
+import { alertDialog, confirmDialog } from "../react/components/dialogs";
 import * as React from "react";
 import { useState } from "react";
 import { Accounts } from "meteor/accounts-base";
 import { Meteor } from "meteor/meteor";
 import { useTracker } from "meteor/react-meteor-data";
 
+import User from "../../collections/lib/classes/User";
 import * as UserCollection from "../../collections/lib/UserCollection";
+import { callMethod } from "../../imports/methods/MethodContracts";
 import { InlineAlert, InlineAlerts } from "../react/components/InlineAlerts";
 
 const GENDER_OPTIONS = [
@@ -195,6 +197,149 @@ function ProfileDataForm(props: { user: Meteor.User }): JSX.Element {
   );
 }
 
+// Kalender-Abo (iCal): zeigt den persönlichen Feed-Link an. Der Token wird
+// erst auf Klick per Methode erzeugt/geholt — er ist bewusst nicht publiziert.
+function CalendarSubscriptionCard(): JSX.Element {
+  const [feedUrl, setFeedUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const urlForToken = (token: string) => `${window.location.origin}/api/calendar/${token}.ics`;
+
+  const showLink = () => {
+    callMethod("getCalendarToken")
+      .then((token) => setFeedUrl(urlForToken(token)))
+      .catch((err) => {
+        console.error(err);
+        void alertDialog("Der Kalender-Link konnte nicht erzeugt werden.", "Fehler");
+      });
+  };
+
+  const resetLink = () => {
+    void confirmDialog({
+      title: "Kalender-Link erneuern",
+      message:
+        "Der bisherige Kalender-Link wird ungültig — bestehende Abos in deinen " +
+        "Kalender-Apps musst du danach neu einrichten. Fortfahren?",
+      yesVariant: "danger",
+    }).then((yes) => {
+      if (!yes) {
+        return;
+      }
+      callMethod("resetCalendarToken")
+        .then((token) => {
+          setFeedUrl(urlForToken(token));
+          setCopied(false);
+        })
+        .catch((err) => {
+          console.error(err);
+          void alertDialog("Der Kalender-Link konnte nicht erneuert werden.", "Fehler");
+        });
+    });
+  };
+
+  const copyLink = () => {
+    if (!feedUrl) {
+      return;
+    }
+    void navigator.clipboard
+      .writeText(feedUrl)
+      .then(() => setCopied(true))
+      .catch(() => setCopied(false));
+  };
+
+  return (
+    <div className="card card-primary">
+      <div className="card-header">
+        <i className="fa fa-calendar fa-fw"></i> Kalender-Abo (iCal)
+      </div>
+      <div className="card-body">
+        <p className="small">
+          Abonniere deine Einsätze in deiner Kalender-App (Google, Apple, Outlook …). Neue
+          Teilnahmen, Bewerbungen und Absagen erscheinen dort automatisch. Behandle den Link wie ein
+          Passwort — jeder, der ihn kennt, kann deine Termine sehen.
+        </p>
+        {feedUrl ? (
+          <div>
+            <div className="form-group">
+              <input
+                id="calendarFeedUrl"
+                type="text"
+                className="form-control"
+                readOnly
+                value={feedUrl}
+                onFocus={(e) => e.target.select()}
+              />
+            </div>
+            <button type="button" className="btn btn-primary copy-calendar-url" onClick={copyLink}>
+              <i className="fa fa-clipboard"></i> {copied ? "Kopiert!" : "Link kopieren"}
+            </button>{" "}
+            <button
+              type="button"
+              className="btn btn-outline-danger reset-calendar-url"
+              onClick={resetLink}
+            >
+              <i className="fa fa-refresh"></i> Link erneuern
+            </button>
+          </div>
+        ) : (
+          <button type="button" className="btn btn-primary show-calendar-url" onClick={showLink}>
+            <i className="fa fa-link"></i> Kalender-Link anzeigen
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Self-Service für Koordinatoren: bei welchen neuen Bewerbungen auf Einsätze
+// der eigenen Gruppen benachrichtigt werden soll.
+function ApplicationNotifySettings(props: {
+  profile: UserCollection.UserProfile;
+  setProfileField: (field: string, value: any) => void;
+}): JSX.Element {
+  const mode = props.profile.applicationNotifyMode ?? "all";
+  const days = props.profile.applicationNotifyDays ?? 7;
+
+  return (
+    <div style={{ marginTop: "10px" }}>
+      <div className="form-group">
+        <label htmlFor="applicationNotifyMode">
+          Bei neuen Bewerbungen auf Einsätze meiner Gruppen
+        </label>
+        <select
+          id="applicationNotifyMode"
+          className="form-control"
+          value={mode}
+          onChange={(e) => props.setProfileField("profile.applicationNotifyMode", e.target.value)}
+        >
+          <option value="all">Immer benachrichtigen</option>
+          <option value="nearOnly">Nur wenn der Einsatz bald stattfindet</option>
+          <option value="none">Nie benachrichtigen</option>
+        </select>
+      </div>
+      {mode === "nearOnly" ? (
+        <div className="form-group">
+          <label htmlFor="applicationNotifyDays">Nur wenn der Einsatz beginnt in (Tagen)</label>
+          <input
+            id="applicationNotifyDays"
+            type="number"
+            className="form-control"
+            min={1}
+            max={60}
+            value={days}
+            onChange={(e) => {
+              const value = Number(e.target.value);
+              if (Number.isFinite(value) && value >= 1 && value <= 60) {
+                props.setProfileField("profile.applicationNotifyDays", value);
+              }
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ChangePasswordForm(): JSX.Element {
   const [oldPassword, setOldPassword] = useState("");
   const [password, setPassword] = useState("");
@@ -281,6 +426,17 @@ function ChangePasswordForm(): JSX.Element {
 
 export default function ModifyProfile(): JSX.Element {
   const user = useTracker(() => Meteor.user());
+  // Die Bewerbungs-Benachrichtigung betrifft nur Koordinatoren — für alle
+  // anderen bleibt die Karte unverändert schlank.
+  const isCoordinator = useTracker(() => {
+    Meteor.subscribe("coordinatingGroups");
+    const userId = Meteor.userId();
+    if (!userId) {
+      return false;
+    }
+    const current = new User(userId);
+    return current.exists() ? current.isCoordinatorInAnyGroup(true) : false;
+  });
 
   if (!user) {
     return <div />;
@@ -339,8 +495,12 @@ export default function ModifyProfile(): JSX.Element {
                   Benachrichtigungen via E-Mail bekommen
                 </label>
               </div>
+              {isCoordinator ? (
+                <ApplicationNotifySettings profile={profile} setProfileField={setProfileField} />
+              ) : null}
             </div>
           </div>
+          <CalendarSubscriptionCard />
           <div className="card card-primary">
             <div className="card-header">Sprache für E-Mail-Benachrichtigungen</div>
             <div className="card-body">

--- a/src/collections/lib/AssignmentsCollection.ts
+++ b/src/collections/lib/AssignmentsCollection.ts
@@ -43,6 +43,11 @@ export interface AssignmentDAO {
   year?: number;
   isoWeek?: number;
   yearOfIsoWeek?: number;
+  /**
+   * Zeitpunkt, zu dem die Teilnehmer-Erinnerungen für diesen Einsatz
+   * verschickt wurden (AssignmentReminder). Fehlt = noch nicht erinnert.
+   */
+  remindersSentAt?: Date;
 }
 
 const AssignmentStateNames = EnumUtil.getNames(AssignmentState);
@@ -240,6 +245,14 @@ export const AssignmentSchema = new SimpleSchema({
     type: String,
     optional: true,
     label: "Abholung",
+  },
+  // Erinnerungs-Stempel des Reminder-Schedulers. Wird per bypassCollection2
+  // gesetzt (kein updatedAt-Restamp), steht aber im Schema, damit das Feld
+  // dokumentiert und bei Voll-Validierungen bekannt ist.
+  remindersSentAt: {
+    type: Date,
+    label: "Erinnerungen verschickt am",
+    optional: true,
   },
   return_point: {
     type: String,

--- a/src/collections/lib/UserCollection.ts
+++ b/src/collections/lib/UserCollection.ts
@@ -2,6 +2,16 @@ import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { Locale } from "../../imports/i18n/classes/I18nProvider";
 
+/**
+ * Self-Service-Einstellung eines Koordinators: bei welchen neuen Bewerbungen
+ * auf Einsätze seiner Gruppen er benachrichtigt werden möchte.
+ * - "all": immer (Default, wenn nicht gesetzt)
+ * - "nearOnly": nur wenn der Einsatz in den nächsten `applicationNotifyDays`
+ *   Tagen liegt
+ * - "none": nie
+ */
+export type ApplicationNotifyMode = "all" | "nearOnly" | "none";
+
 export interface UserProfile {
   first_name?: string;
   last_name?: string;
@@ -17,6 +27,8 @@ export interface UserProfile {
   zip?: string;
   placeName?: string;
   notificationAsEmail?: boolean;
+  applicationNotifyMode?: ApplicationNotifyMode;
+  applicationNotifyDays?: number;
 }
 
 /**
@@ -41,6 +53,13 @@ export interface UserDAO extends Meteor.User {
   banned?: boolean;
   notice?: string;
   termsOfUse?: TermsOfUseConsent;
+  /**
+   * Geheimer Token für das persönliche iCal-Kalenderabo (/api/calendar/…).
+   * Wird ausschließlich serverseitig erzeugt (getCalendarToken-Method), nie
+   * publiziert und ist über die users-Allow-Rule nicht durch den Client
+   * änderbar — wer den Token kennt, kann die Termine des Users lesen.
+   */
+  calendarToken?: string;
 }
 
 export const users: Mongo.Collection<UserDAO> = <Mongo.Collection<UserDAO>>(<any>Meteor.users);

--- a/src/collections/lib/Users.ts
+++ b/src/collections/lib/Users.ts
@@ -161,6 +161,22 @@ export const UserProfileSchema = new SimpleSchema({
     label: "Benachrichtigungen via E-Mail bekommen",
     optional: true,
   },
+  // Self-Service für Koordinatoren: bei welchen neuen Bewerbungen auf
+  // Einsätze der eigenen Gruppen benachrichtigt werden soll (siehe
+  // ApplicationNotifyMode in UserCollection.ts). Fehlend = "all".
+  applicationNotifyMode: {
+    type: String,
+    label: "Benachrichtigung bei neuen Bewerbungen",
+    allowedValues: ["all", "nearOnly", "none"],
+    optional: true,
+  },
+  applicationNotifyDays: {
+    type: Number,
+    label: "Nur wenn der Einsatz in den nächsten X Tagen liegt",
+    min: 1,
+    max: 365,
+    optional: true,
+  },
   pendingGroups: {
     type: Array,
     label: "Ausstehende Gruppenbewerbungen",
@@ -339,6 +355,14 @@ export const UserSchema = new SimpleSchema({
   "termsOfUse.acceptedAt": {
     type: Date,
     label: "Zeitpunkt der Zustimmung",
+  },
+  // Geheimer Token des persönlichen iCal-Kalenderabos. Nur serverseitig
+  // gesetzt (getCalendarToken/resetCalendarToken) und bewusst in keiner
+  // Publikation enthalten.
+  calendarToken: {
+    type: String,
+    label: "Kalender-Abo-Token",
+    optional: true,
   },
 });
 

--- a/src/collections/lib/classes/UserNotification.ts
+++ b/src/collections/lib/classes/UserNotification.ts
@@ -53,7 +53,10 @@ export const NotificationDataSchema = new SimpleSchema({
   },
   link: {
     type: String,
-    regEx: SimpleSchema.RegEx.Url,
+    // Relative App-Pfade ODER absolute http(s)-URLs. Der frühere
+    // SimpleSchema.RegEx.Url verlangte eine TLD und lehnte damit sowohl
+    // In-App-Pfade ("/einsatz/…") als auch localhost-URLs (dev/e2e) ab.
+    regEx: /^(\/\S*|https?:\/\/\S+)$/,
     optional: true,
     custom: function (this: SchemaContext) {
       let context = <any>this;

--- a/src/imports/calendar/Ics.ts
+++ b/src/imports/calendar/Ics.ts
@@ -1,0 +1,103 @@
+/**
+ * Minimaler, reiner iCalendar-Builder (RFC 5545) für das persönliche
+ * Kalender-Abo. Bewusst ohne Fremdbibliothek: gebraucht werden nur
+ * VCALENDAR/VEVENT mit UTC-Zeiten, Escaping und Zeilen-Folding — dafür lohnt
+ * keine Dependency. Pure Funktionen, damit sie unter Mocha testbar sind.
+ */
+
+export type IcsEventStatus = "CONFIRMED" | "TENTATIVE" | "CANCELLED";
+
+export interface IcsEvent {
+  /** Stabil pro Termin (z.B. "<assignmentId>@jw-public.org") — Kalender-Clients aktualisieren darüber. */
+  uid: string;
+  summary: string;
+  start: Date;
+  end: Date;
+  status: IcsEventStatus;
+  description?: string;
+  location?: string;
+  url?: string;
+}
+
+export interface IcsCalendarOptions {
+  /** Anzeigename des Abos im Kalender-Client (X-WR-CALNAME). */
+  name: string;
+  events: IcsEvent[];
+  /** DTSTAMP aller Events; injizierbar für deterministische Tests. */
+  now?: Date;
+}
+
+/** Text-Escaping nach RFC 5545 3.3.11: Backslash, Semikolon, Komma, Zeilenumbrüche. */
+export function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r\n|\r|\n/g, "\\n");
+}
+
+/** UTC-Zeitformat YYYYMMDDTHHMMSSZ. */
+export function formatIcsDateUtc(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`
+  );
+}
+
+/**
+ * Zeilen-Folding nach RFC 5545 3.1: Zeilen sollen 75 Oktette nicht
+ * überschreiten; Fortsetzungszeilen beginnen mit einem Leerzeichen. Gefaltet
+ * wird konservativ nach 60 Zeichen, damit auch Mehrbyte-Zeichen (Umlaute)
+ * sicher unter der Oktett-Grenze bleiben.
+ */
+export function foldIcsLine(line: string): string {
+  const LIMIT = 60;
+  if (line.length <= LIMIT) {
+    return line;
+  }
+  const parts: string[] = [];
+  let rest = line;
+  parts.push(rest.slice(0, LIMIT));
+  rest = rest.slice(LIMIT);
+  while (rest.length > 0) {
+    parts.push(" " + rest.slice(0, LIMIT - 1));
+    rest = rest.slice(LIMIT - 1);
+  }
+  return parts.join("\r\n");
+}
+
+export function buildIcsCalendar(options: IcsCalendarOptions): string {
+  const now = options.now ?? new Date();
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//jw-public//PublicAssistant//DE",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-CALNAME:${escapeIcsText(options.name)}`,
+  ];
+
+  for (const event of options.events) {
+    lines.push("BEGIN:VEVENT");
+    lines.push(`UID:${escapeIcsText(event.uid)}`);
+    lines.push(`DTSTAMP:${formatIcsDateUtc(now)}`);
+    lines.push(`DTSTART:${formatIcsDateUtc(event.start)}`);
+    lines.push(`DTEND:${formatIcsDateUtc(event.end)}`);
+    lines.push(`SUMMARY:${escapeIcsText(event.summary)}`);
+    lines.push(`STATUS:${event.status}`);
+    if (event.location) {
+      lines.push(`LOCATION:${escapeIcsText(event.location)}`);
+    }
+    if (event.description) {
+      lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`);
+    }
+    if (event.url) {
+      lines.push(`URL:${escapeIcsText(event.url)}`);
+    }
+    lines.push("END:VEVENT");
+  }
+
+  lines.push("END:VCALENDAR");
+  return lines.map(foldIcsLine).join("\r\n") + "\r\n";
+}

--- a/src/imports/i18n/interfaces/ILocale.ts
+++ b/src/imports/i18n/interfaces/ILocale.ts
@@ -19,9 +19,25 @@ export interface IAssignmentEmailLocale {
   };
 }
 
+/** E-Mail an Koordinatoren: neue Bewerbung auf einen Einsatz ihrer Gruppe. */
+export interface IApplicationEmailLocale {
+  subject(assignmentName: string, date: string): string;
+  message(applicantName: string, assignmentName: string, date: string): string;
+  linkToAssignment: string;
+}
+
+/** Erinnerungs-E-Mail an Teilnehmer vor Beginn eines Einsatzes. */
+export interface IReminderEmailLocale {
+  subject(assignmentName: string, date: string): string;
+  message(assignmentName: string, date: string): string;
+  linkToAssignment: string;
+}
+
 export interface ILocale {
   hello: string;
   assignmentEmail: IAssignmentEmailLocale;
+  applicationEmail: IApplicationEmailLocale;
+  reminderEmail: IReminderEmailLocale;
   dateFormats: {
     shortDateTime: string;
     longDateTime: string;

--- a/src/imports/i18n/locales/de.ts
+++ b/src/imports/i18n/locales/de.ts
@@ -51,6 +51,24 @@ Dort findest du die Kontaktdaten. Bitte sende uns deinen Bericht dieser Schicht 
 export const messages: ILocale = {
   hello: "Hallo",
   assignmentEmail: assignmentLocale,
+  applicationEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `Neue Bewerbung für Trolley ${assignmentName} am ${date}`;
+    },
+    message(applicantName: string, assignmentName: string, date: string): string {
+      return `${applicantName} hat sich auf den Trolleydienst ${assignmentName} am ${date} beworben.`;
+    },
+    linkToAssignment: "Link zum Termin",
+  },
+  reminderEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `Erinnerung: Trolley ${assignmentName} am ${date}`;
+    },
+    message(assignmentName: string, date: string): string {
+      return `dein Trolleydienst ${assignmentName} am ${date} steht bevor. Wir freuen uns auf dich!`;
+    },
+    linkToAssignment: "Link zum Termin",
+  },
   dateFormats: {
     shortDateTime: "llll",
     longDateTime: "dddd, Do MMM [um] LT",

--- a/src/imports/i18n/locales/en.ts
+++ b/src/imports/i18n/locales/en.ts
@@ -47,6 +47,24 @@ There you will find the contact details.`,
 export const messages: ILocale = {
   hello: "Hello",
   assignmentEmail: assignmentLocale,
+  applicationEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `New application for Trolley ${assignmentName} on ${date}`;
+    },
+    message(applicantName: string, assignmentName: string, date: string): string {
+      return `${applicantName} applied for the trolley ${assignmentName} on ${date}.`;
+    },
+    linkToAssignment: "Link to assignment",
+  },
+  reminderEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `Reminder: Trolley ${assignmentName} on ${date}`;
+    },
+    message(assignmentName: string, date: string): string {
+      return `your trolley ${assignmentName} on ${date} is coming up. We are looking forward to seeing you!`;
+    },
+    linkToAssignment: "Link to assignment",
+  },
   dateFormats: {
     shortDateTime: "llll",
     longDateTime: "dddd, Do MMM [at] LT",

--- a/src/imports/i18n/locales/fr.ts
+++ b/src/imports/i18n/locales/fr.ts
@@ -46,6 +46,24 @@ Si tu veux contacter ton responsable, clique sur le lien ci-dessus pour y trouve
 export const messages: ILocale = {
   hello: "Bonjour",
   assignmentEmail: assignmentLocale,
+  applicationEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `Nouvelle candidature pour le présentoir ${assignmentName}, le ${date}`;
+    },
+    message(applicantName: string, assignmentName: string, date: string): string {
+      return `${applicantName} a postulé pour le service du présentoir ${assignmentName} le ${date}.`;
+    },
+    linkToAssignment: "Voici le lien pour plus d’information",
+  },
+  reminderEmail: {
+    subject(assignmentName: string, date: string): string {
+      return `Rappel : présentoir ${assignmentName}, le ${date}`;
+    },
+    message(assignmentName: string, date: string): string {
+      return `ton service du présentoir ${assignmentName} le ${date} approche. Nous nous réjouissons de te voir !`;
+    },
+    linkToAssignment: "Voici le lien pour plus d’information",
+  },
   dateFormats: {
     shortDateTime: "ddd L hh[h]mm",
     longDateTime: "dddd, [le] Do MMM YYYY [à] hh[h]mm",

--- a/src/imports/methods/MethodContracts.ts
+++ b/src/imports/methods/MethodContracts.ts
@@ -47,6 +47,8 @@ export interface MethodSignatures {
   validatePhoneNumber: { args: [phoneNumber: string]; result: boolean };
   removeUser: { args: [userToRemoveId: string]; result: void };
   acceptTermsOfUse: { args: []; result: void };
+  getCalendarToken: { args: []; result: string };
+  resetCalendarToken: { args: []; result: string };
   adminInactivityReport: { args: [thresholdDays: number]; result: InactivityReport };
   adminDeleteGroup: { args: [groupId: string]; result: { removedAssignments: number } };
 }

--- a/src/server/assignments/classes/ApplicationCoordinatorNotifier.ts
+++ b/src/server/assignments/classes/ApplicationCoordinatorNotifier.ts
@@ -1,0 +1,144 @@
+import moment from "moment";
+
+import { AssignmentDAO } from "../../../collections/lib/AssignmentsCollection";
+import { GroupDAO } from "../../../collections/lib/GroupCollection";
+import { NotificationDAO } from "../../../collections/lib/classes/UserNotification";
+import { ApplicationNotifyMode, UserDAO } from "../../../collections/lib/UserCollection";
+import { SimpleCollection } from "../../../imports/interfaces/SimpleCollection";
+import { Logger } from "../../../imports/logging/Logger";
+import { LoggerFactory } from "../../../imports/logging/LoggerFactory";
+import { IUserMailer } from "../../mailing/interfaces/IUserMailer";
+import { IUserSettingsReaderFactory } from "../../user/interfaces/IUserSettingsReaderFactory";
+
+export interface IApplicationCoordinatorNotifier {
+  notifyCoordinatorsAboutApplication(
+    assignmentId: string,
+    applicantId: string,
+    now?: Date,
+  ): Promise<void>;
+}
+
+/**
+ * Benachrichtigt die Koordinatoren einer Gruppe über eine neue Bewerbung auf
+ * einen Einsatz: In-App immer (sofern nicht abbestellt), E-Mail zusätzlich
+ * bei aktiviertem notificationAsEmail. Jeder Koordinator steuert das selbst
+ * über profile.applicationNotifyMode / applicationNotifyDays:
+ * - "all" (Default): jede Bewerbung
+ * - "nearOnly": nur wenn der Einsatz in den nächsten X Tagen beginnt
+ * - "none": nie
+ * Der Bewerber selbst wird nie benachrichtigt (Selbstbewerbung eines
+ * Koordinators erzeugt sonst Rauschen).
+ */
+export class ApplicationCoordinatorNotifier implements IApplicationCoordinatorNotifier {
+  private logger: Logger;
+
+  constructor(
+    private assignments: SimpleCollection<AssignmentDAO>,
+    private users: SimpleCollection<UserDAO>,
+    private groups: SimpleCollection<GroupDAO>,
+    private notifications: SimpleCollection<NotificationDAO>,
+    private userMailer: IUserMailer,
+    private userSettingsReaderFactory: IUserSettingsReaderFactory,
+    loggerFactory: LoggerFactory,
+  ) {
+    this.logger = loggerFactory.createLogger("ApplicationCoordinatorNotifier");
+  }
+
+  public async notifyCoordinatorsAboutApplication(
+    assignmentId: string,
+    applicantId: string,
+    now: Date = new Date(),
+  ): Promise<void> {
+    const assignment = await this.assignments.findOneAsync({ _id: assignmentId });
+    if (!assignment) {
+      return;
+    }
+    const group = await this.groups.findOneAsync({ _id: assignment.group });
+    const applicant = await this.users.findOneAsync({ _id: applicantId });
+    const applicantName = this.fullName(applicant) ?? "Ein Verkündiger";
+
+    const coordinatorIds = (group?.coordinators ?? []).filter((id) => id !== applicantId);
+    for (const coordinatorId of coordinatorIds) {
+      try {
+        await this.notifyCoordinator(coordinatorId, assignment, applicantName, group, now);
+      } catch (error) {
+        // Ein kaputter Empfänger darf weder die Bewerbung noch die übrigen
+        // Koordinatoren blockieren.
+        this.logger.error(
+          `Failed to notify coordinator ${coordinatorId} about application on ${assignmentId}: ${error}`,
+        );
+      }
+    }
+  }
+
+  private async notifyCoordinator(
+    coordinatorId: string,
+    assignment: AssignmentDAO,
+    applicantName: string,
+    group: GroupDAO | undefined,
+    now: Date,
+  ): Promise<void> {
+    const coordinator = await this.users.findOneAsync({ _id: coordinatorId });
+    if (!coordinator) {
+      return;
+    }
+
+    const mode: ApplicationNotifyMode = coordinator.profile?.applicationNotifyMode ?? "all";
+    if (mode === "none") {
+      return;
+    }
+    if (mode === "nearOnly") {
+      const days = coordinator.profile?.applicationNotifyDays ?? 7;
+      const windowEnd = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+      if (assignment.start > windowEnd) {
+        return;
+      }
+    }
+
+    // In-App-Benachrichtigung (Texte in-App sind app-weit deutsch). Der
+    // type-String ist wie im AssignmentNotifier hartkodiert: ein Wert-Import
+    // aus UserNotification zöge dessen Meteor-Kette in die Node-Unit-Tests.
+    await this.notifications.insertAsync({
+      type: "Simple",
+      userId: coordinatorId,
+      simpleData: {
+        title: "Neue Bewerbung",
+        details:
+          `${applicantName} hat sich auf den Einsatz "${assignment.name}" ` +
+          `am ${moment(assignment.start).format("L LT")} beworben.`,
+        icon: "fa fa-user-plus",
+        hasLink: true,
+        link: `/einsatz/${assignment._id}`,
+      },
+    });
+
+    // E-Mail nur bei aktiviertem Opt-in, lokalisiert in der Sprache des
+    // Koordinators (gleiches Muster wie AssignmentEmailNotifier).
+    const settings = await this.userSettingsReaderFactory.createSettingsReaderFor(coordinatorId);
+    if (!settings.wantsToReceiveNotificationAsEmail()) {
+      return;
+    }
+    const i18n = settings.getI18nProvider();
+    const locale = i18n.getI18n();
+    const date = i18n.getDateParser().getLongDateTimeAsString(assignment.start);
+    const assignmentUrl = `${process.env.ROOT_URL}/einsatz/${assignment._id}`;
+
+    await this.userMailer.send({
+      recepientId: coordinatorId,
+      subject: locale.applicationEmail.subject(assignment.name, date),
+      markdownContent: `${locale.hello} ${coordinator.profile?.first_name ?? ""},
+
+${locale.applicationEmail.message(applicantName, assignment.name, date)}
+
+${locale.applicationEmail.linkToAssignment}: ${assignmentUrl}`,
+      replyToAddress: group?.email,
+    });
+  }
+
+  private fullName(user: UserDAO | undefined): string | undefined {
+    const first = user?.profile?.first_name;
+    const last = user?.profile?.last_name;
+    const name = [first, last].filter(Boolean).join(" ");
+    return name.length > 0 ? name : undefined;
+  }
+}

--- a/src/server/assignments/classes/AssignmentReminder.ts
+++ b/src/server/assignments/classes/AssignmentReminder.ts
@@ -1,0 +1,131 @@
+import moment from "moment";
+
+import { AssignmentDAO } from "../../../collections/lib/AssignmentsCollection";
+import { AssignmentState } from "../../../collections/lib/classes/AssignmentState";
+import { GroupDAO } from "../../../collections/lib/GroupCollection";
+import { NotificationDAO } from "../../../collections/lib/classes/UserNotification";
+import { UserDAO } from "../../../collections/lib/UserCollection";
+import { SimpleCollection } from "../../../imports/interfaces/SimpleCollection";
+import { Logger } from "../../../imports/logging/Logger";
+import { LoggerFactory } from "../../../imports/logging/LoggerFactory";
+import { IUserMailer } from "../../mailing/interfaces/IUserMailer";
+import { IUserSettingsReaderFactory } from "../../user/interfaces/IUserSettingsReaderFactory";
+
+export interface IAssignmentReminder {
+  sendDueReminders(now?: Date): Promise<number>;
+}
+
+/**
+ * Erinnert Teilnehmer an bevorstehende Einsätze: alle Einsätze, die innerhalb
+ * des Erinnerungsfensters (Default 24h) beginnen, noch nicht erinnert wurden
+ * und nicht abgesagt sind. Pro Teilnehmer: In-App-Benachrichtigung immer,
+ * E-Mail zusätzlich bei aktiviertem notificationAsEmail (lokalisiert).
+ *
+ * Idempotenz: `remindersSentAt` wird VOR dem Versand gestempelt (claim
+ * first) — ein Crash mitten im Versand kostet schlimmstenfalls einzelne
+ * Erinnerungen, erzeugt aber nie Duplikat-Spam. Der Stempel wird mit
+ * bypassCollection2 geschrieben, damit weder updatedAt noch die
+ * participants/applicants-AutoValues angefasst werden (eine Erinnerung ist
+ * keine inhaltliche Änderung des Termins).
+ */
+export class AssignmentReminder implements IAssignmentReminder {
+  private logger: Logger;
+
+  constructor(
+    private assignments: SimpleCollection<AssignmentDAO>,
+    private users: SimpleCollection<UserDAO>,
+    private groups: SimpleCollection<GroupDAO>,
+    private notifications: SimpleCollection<NotificationDAO>,
+    private userMailer: IUserMailer,
+    private userSettingsReaderFactory: IUserSettingsReaderFactory,
+    loggerFactory: LoggerFactory,
+    private windowHours: number = 24,
+  ) {
+    this.logger = loggerFactory.createLogger("AssignmentReminder");
+  }
+
+  /** @returns Anzahl der Einsätze, für die Erinnerungen verschickt wurden. */
+  public async sendDueReminders(now: Date = new Date()): Promise<number> {
+    const windowEnd = new Date(now.getTime() + this.windowHours * 60 * 60 * 1000);
+
+    const due = (
+      await this.assignments
+        .find({
+          start: { $gt: now, $lte: windowEnd },
+          remindersSentAt: { $exists: false },
+          state: { $ne: AssignmentState[AssignmentState.Canceled] },
+        })
+        .fetchAsync()
+    ).filter((assignment) => (assignment.participants ?? []).length > 0);
+
+    let remindedCount = 0;
+    for (const assignment of due) {
+      // Claim first: Stempeln vor dem Versand verhindert Duplikate, falls
+      // ein zweiter Lauf parallel startet oder der Versand abbricht.
+      const claimed = await this.assignments.updateAsync(
+        { _id: assignment._id, remindersSentAt: { $exists: false } },
+        { $set: { remindersSentAt: now } },
+        { bypassCollection2: true } as any,
+      );
+      if (claimed === 0) {
+        continue;
+      }
+      remindedCount++;
+
+      for (const participant of assignment.participants) {
+        try {
+          await this.remindParticipant(participant.user, assignment);
+        } catch (error) {
+          this.logger.error(
+            `Failed to remind user ${participant.user} about assignment ${assignment._id}: ${error}`,
+          );
+        }
+      }
+    }
+    return remindedCount;
+  }
+
+  private async remindParticipant(userId: string, assignment: AssignmentDAO): Promise<void> {
+    // In-App-Benachrichtigung (Texte in-App sind app-weit deutsch). Der
+    // type-String ist wie im AssignmentNotifier hartkodiert: ein Wert-Import
+    // aus UserNotification zöge dessen Meteor-Kette in die Node-Unit-Tests.
+    await this.notifications.insertAsync({
+      type: "Simple",
+      userId,
+      simpleData: {
+        title: "Erinnerung an deinen Einsatz",
+        details:
+          `Dein Einsatz "${assignment.name}" ` +
+          `am ${moment(assignment.start).format("L LT")} steht bevor.`,
+        icon: "fa fa-clock-o",
+        hasLink: true,
+        link: `/einsatz/${assignment._id}`,
+      },
+    });
+
+    const settings = await this.userSettingsReaderFactory.createSettingsReaderFor(userId);
+    if (!settings.wantsToReceiveNotificationAsEmail()) {
+      return;
+    }
+    const user = await this.users.findOneAsync({ _id: userId });
+    if (!user) {
+      return;
+    }
+    const group = await this.groups.findOneAsync({ _id: assignment.group });
+    const i18n = settings.getI18nProvider();
+    const locale = i18n.getI18n();
+    const date = i18n.getDateParser().getLongDateTimeAsString(assignment.start);
+    const assignmentUrl = `${process.env.ROOT_URL}/einsatz/${assignment._id}`;
+
+    await this.userMailer.send({
+      recepientId: userId,
+      subject: locale.reminderEmail.subject(assignment.name, date),
+      markdownContent: `${locale.hello} ${user.profile?.first_name ?? ""},
+
+${locale.reminderEmail.message(assignment.name, date)}
+
+${locale.reminderEmail.linkToAssignment}: ${assignmentUrl}`,
+      replyToAddress: group?.email,
+    });
+  }
+}

--- a/src/server/calendar/CalendarFeed.ts
+++ b/src/server/calendar/CalendarFeed.ts
@@ -1,0 +1,109 @@
+import { Meteor } from "meteor/meteor";
+import { WebApp } from "meteor/webapp";
+
+import { Assignments } from "../../collections/lib/AssignmentsCollection";
+import { AssignmentState } from "../../collections/lib/classes/AssignmentState";
+import { buildIcsCalendar, IcsEvent } from "../../imports/calendar/Ics";
+
+/**
+ * Persönliches iCal-Kalenderabo: GET /api/calendar/<token>.ics
+ *
+ * Der Token (siehe getCalendarToken-Method) ist das einzige Credential —
+ * hohe Entropie (160 bit), nie publiziert, per resetCalendarToken
+ * widerrufbar. Kalender-Clients (Google/Apple/Outlook) pollen die URL und
+ * halten die Termine des Users automatisch aktuell:
+ * - Teilnahmen  -> STATUS:CONFIRMED
+ * - Bewerbungen -> STATUS:TENTATIVE (Prefix "Bewerbung:")
+ * - Abgesagte   -> STATUS:CANCELLED (Prefix "Abgesagt:")
+ */
+
+const TOKEN_PATH = /^\/([a-fA-F0-9]{40})\.ics$/;
+const LOOKBACK_DAYS = 30;
+const MAX_EVENTS = 500;
+
+WebApp.connectHandlers.use("/api/calendar", (req, res) => {
+  void (async () => {
+    try {
+      const path = (req.url ?? "").split("?")[0];
+      const match = TOKEN_PATH.exec(path);
+      if (!match || req.method !== "GET") {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+        return;
+      }
+
+      const user = await Meteor.users.findOneAsync(
+        { calendarToken: match[1] },
+        { fields: { _id: 1, "profile.first_name": 1 } },
+      );
+      if (!user) {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+        return;
+      }
+
+      const since = new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+      const assignments = await Assignments.find(
+        {
+          $or: [{ "participants.user": user._id }, { "applicants.user": user._id }],
+          start: { $gte: since },
+        },
+        {
+          sort: { start: 1 },
+          limit: MAX_EVENTS,
+          fields: {
+            name: 1,
+            start: 1,
+            end: 1,
+            state: 1,
+            note: 1,
+            pickup_point: 1,
+            "participants.user": 1,
+            "applicants.user": 1,
+          },
+        },
+      ).fetchAsync();
+
+      const rootUrl = (process.env.ROOT_URL ?? "").replace(/\/$/, "");
+      const events: IcsEvent[] = assignments.map((assignment) => {
+        const isParticipant = (assignment.participants ?? []).some((e) => e.user === user._id);
+        const isCanceled = assignment.state === AssignmentState[AssignmentState.Canceled];
+
+        let status: IcsEvent["status"] = isParticipant ? "CONFIRMED" : "TENTATIVE";
+        let summary = isParticipant ? assignment.name : `Bewerbung: ${assignment.name}`;
+        if (isCanceled) {
+          status = "CANCELLED";
+          summary = `Abgesagt: ${assignment.name}`;
+        }
+
+        return {
+          uid: `${assignment._id}@jw-public.org`,
+          summary,
+          start: assignment.start,
+          end: assignment.end,
+          status,
+          location: assignment.pickup_point,
+          description: assignment.note,
+          url: `${rootUrl}/einsatz/${assignment._id}`,
+        };
+      });
+
+      const ics = buildIcsCalendar({ name: "PublicAssistant – Meine Einsätze", events });
+      res.writeHead(200, {
+        "Content-Type": "text/calendar; charset=utf-8",
+        "Content-Disposition": 'inline; filename="publicassistant.ics"',
+        "Cache-Control": "private, no-cache",
+      });
+      res.end(ics);
+    } catch (error) {
+      console.error("Calendar feed failed:", error);
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Internal error");
+    }
+  })();
+});
+
+// Der Feed sucht Users über calendarToken — sparse Index statt Collection-Scan.
+Meteor.startup(async () => {
+  await Meteor.users.rawCollection().createIndex({ calendarToken: 1 }, { sparse: true });
+});

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -6,6 +6,7 @@ import { MethodImplementations } from "../imports/methods/MethodContracts";
 import * as RolesHelper from "../lib/RolesHelper";
 import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
+import { Random } from "meteor/random";
 
 import { Email } from "meteor/email";
 import * as PhoneValidator from "../collections/lib/ValidationFunctions/PhoneValidator";
@@ -260,6 +261,18 @@ Meteor.startup(function () {
         await app
           .assignmentApplicationControllerFactory(assignmentId)
           .addUserAsApplicantById(this.userId);
+
+        // Koordinatoren über die neue Bewerbung informieren (In-App + Mail,
+        // je nach deren Self-Service-Einstellung). Fehler hier dürfen die
+        // bereits gespeicherte Bewerbung nicht rückwirkend scheitern lassen.
+        try {
+          await app.applicationCoordinatorNotifier.notifyCoordinatorsAboutApplication(
+            assignmentId,
+            this.userId,
+          );
+        } catch (error) {
+          console.error("Failed to notify coordinators about application:", error);
+        }
       } else {
         throw new Meteor.Error("403", "Access denied.");
       }
@@ -577,6 +590,48 @@ Meteor.startup(function () {
         `Deleted group ${group.name} (${groupId}) with ${removedAssignments} assignments (by ${this.userId})`,
       );
       return { removedAssignments };
+    },
+
+    /**
+     * Liefert den geheimen Token des persönlichen iCal-Kalenderabos des
+     * eingeloggten Users und erzeugt ihn beim ersten Aufruf. Der Token wird
+     * bewusst nie publiziert — nur wer ihn kennt, kann den Feed lesen.
+     */
+    getCalendarToken: async function (): Promise<string> {
+      if (!this.userId) {
+        throw new Meteor.Error("403", "Access denied");
+      }
+      const user = (await Meteor.users.findOneAsync(
+        { _id: this.userId },
+        { fields: { calendarToken: 1 } },
+      )) as UserCollection.UserDAO | undefined;
+      if (user?.calendarToken) {
+        return user.calendarToken;
+      }
+      // Nur setzen, wenn noch keiner existiert (Guard gegen parallele Calls);
+      // danach autoritativ zurücklesen.
+      await Meteor.users.updateAsync(
+        { _id: this.userId, calendarToken: { $exists: false } },
+        { $set: { calendarToken: Random.hexString(40) } },
+      );
+      const after = (await Meteor.users.findOneAsync(
+        { _id: this.userId },
+        { fields: { calendarToken: 1 } },
+      )) as UserCollection.UserDAO | undefined;
+      return after!.calendarToken!;
+    },
+
+    /**
+     * Erzeugt einen neuen Kalender-Abo-Token (macht den alten Feed-Link
+     * ungültig — z.B. wenn er versehentlich geteilt wurde).
+     */
+    resetCalendarToken: async function (): Promise<string> {
+      if (!this.userId) {
+        throw new Meteor.Error("403", "Access denied");
+      }
+      const token = Random.hexString(40);
+      await Meteor.users.updateAsync({ _id: this.userId }, { $set: { calendarToken: token } });
+      return token;
     },
 
     /**

--- a/src/server/reminders.ts
+++ b/src/server/reminders.ts
@@ -1,0 +1,27 @@
+import { Meteor } from "meteor/meteor";
+import { app } from "./App";
+
+/**
+ * Reminder-Scheduler: erinnert Teilnehmer an Einsätze, die innerhalb der
+ * nächsten 24h beginnen (siehe AssignmentReminder). Läuft alle 15 Minuten
+ * plus einmal direkt nach dem Start (Catch-up nach Deploys/Restarts);
+ * Duplikate verhindert der remindersSentAt-Stempel am Assignment, nicht der
+ * Timer — der Intervallwert ist daher unkritisch.
+ */
+const REMINDER_INTERVAL_MS = 15 * 60 * 1000;
+
+Meteor.startup(() => {
+  const run = async () => {
+    try {
+      const reminded = await app.assignmentReminder.sendDueReminders();
+      if (reminded > 0) {
+        console.log(`AssignmentReminder: sent reminders for ${reminded} assignment(s)`);
+      }
+    } catch (error) {
+      console.error("AssignmentReminder run failed:", error);
+    }
+  };
+
+  void run();
+  Meteor.setInterval(() => void run(), REMINDER_INTERVAL_MS);
+});

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -11,8 +11,10 @@ import { SimpleCollection } from "../imports/interfaces/SimpleCollection";
 import { LoggerFactory } from "../imports/logging/LoggerFactory";
 import { SimpleConsoleLoggerFactory } from "../imports/logging/SimpleConsoleLoggerFactory";
 
+import { ApplicationCoordinatorNotifier } from "./assignments/classes/ApplicationCoordinatorNotifier";
 import { AssignmentApplicationController } from "./assignments/classes/AssignmentApplicationController";
 import { AssignmentCanceler } from "./assignments/classes/AssignmentCanceler";
+import { AssignmentReminder } from "./assignments/classes/AssignmentReminder";
 import { AssignmentCloser } from "./assignments/classes/AssignmentCloser";
 import { AssignmentDaoNotifier } from "./assignments/classes/AssignmentDaoNotifier";
 import { AssignmentDateParser } from "./assignments/classes/AssignmentDateParser";
@@ -135,6 +137,26 @@ export function buildServices(
     loggerFactory,
   );
 
+  const applicationCoordinatorNotifier = new ApplicationCoordinatorNotifier(
+    collections.assignments,
+    collections.users,
+    collections.groups,
+    collections.notifications,
+    userMailer,
+    userSettingsReaderFactory,
+    loggerFactory,
+  );
+
+  const assignmentReminder = new AssignmentReminder(
+    collections.assignments,
+    collections.users,
+    collections.groups,
+    collections.notifications,
+    userMailer,
+    userSettingsReaderFactory,
+    loggerFactory,
+  );
+
   return {
     loggerFactory,
     userFactory,
@@ -152,6 +174,8 @@ export function buildServices(
     assignmentReenabler,
     assignmentRemover,
     assignmentWeekCopyPaster,
+    applicationCoordinatorNotifier,
+    assignmentReminder,
     assignments: collections.assignments,
   };
 }

--- a/src/tests/assignments/ApplicationCoordinatorNotifier.test.ts
+++ b/src/tests/assignments/ApplicationCoordinatorNotifier.test.ts
@@ -1,0 +1,193 @@
+import { assert } from "chai";
+
+import { AssignmentDAO } from "../../collections/lib/AssignmentsCollection";
+import { AssignmentCopyActionDAO } from "../../collections/lib/AssignmentCopyActionsCollection";
+import { GroupDAO } from "../../collections/lib/GroupCollection";
+import { NotificationDAO } from "../../collections/lib/classes/UserNotification";
+import { UserDAO } from "../../collections/lib/UserCollection";
+import { SimpleCollection } from "../../imports/interfaces/SimpleCollection";
+import { IUserMailer, IUserMailerOptions } from "../../server/mailing/interfaces/IUserMailer";
+import { IApplicationCoordinatorNotifier } from "../../server/assignments/classes/ApplicationCoordinatorNotifier";
+import { buildServices } from "../../server/services";
+import { LocalCollection } from "../3rdParty/minimongo-standalone/minimongo-standalone";
+import { NullEmailSender } from "../common/NullEmailSender";
+
+const NOW = new Date("2026-07-09T10:00:00Z");
+const daysFromNow = (d: number) => new Date(NOW.getTime() + d * 24 * 60 * 60 * 1000);
+
+class RecordingUserMailer implements IUserMailer {
+  public sent: IUserMailerOptions[] = [];
+  public async send(options: IUserMailerOptions): Promise<void> {
+    this.sent.push(options);
+  }
+}
+
+class TestBed {
+  public users = new LocalCollection<UserDAO>("users");
+  public groups = new LocalCollection<GroupDAO>("groups");
+  public assignments = new LocalCollection<AssignmentDAO>("assignments");
+  public notifications = new LocalCollection<NotificationDAO>("notifications");
+  public mailer = new RecordingUserMailer();
+  public notifier: IApplicationCoordinatorNotifier;
+
+  constructor() {
+    const services = buildServices(
+      {
+        assignments: this.assignments,
+        assignmentCopyActions: new LocalCollection<AssignmentCopyActionDAO>("copyActions"),
+        notifications: this.notifications,
+        users: this.users as unknown as SimpleCollection<UserDAO>,
+        groups: this.groups,
+      },
+      new NullEmailSender(),
+      { userMailer: this.mailer },
+    );
+    this.notifier = services.applicationCoordinatorNotifier;
+  }
+
+  addUser(id: string, profile: object): string {
+    return this.users.insert({
+      _id: id,
+      profile: { first_name: id, last_name: "Test", language: "de-de", ...profile },
+    } as any);
+  }
+
+  addGroupWithAssignment(options: {
+    coordinators: string[];
+    start: Date;
+    groupEmail?: string;
+  }): string {
+    const groupId = this.groups.insert({
+      name: "Testgruppe",
+      coordinators: options.coordinators,
+      email: options.groupEmail,
+    } as any);
+    return this.assignments.insert({
+      name: "Trolley Bahnhof",
+      group: groupId,
+      start: options.start,
+      end: new Date(options.start.getTime() + 2 * 60 * 60 * 1000),
+    } as any);
+  }
+
+  notificationsFor(userId: string): NotificationDAO[] {
+    return this.notifications.find({ userId }).fetch();
+  }
+}
+
+describe("ApplicationCoordinatorNotifier", function () {
+  it("notifies a coordinator in-app and via email about a new application", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", { notificationAsEmail: true });
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(2),
+      groupEmail: "gruppe@jw-public.org",
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    const inApp = bed.notificationsFor("koordinator");
+    assert.lengthOf(inApp, 1);
+    assert.equal(inApp[0].simpleData!.title, "Neue Bewerbung");
+    assert.include(inApp[0].simpleData!.details, "bewerber Test");
+    assert.include(inApp[0].simpleData!.details, "Trolley Bahnhof");
+    assert.equal(inApp[0].simpleData!.link, `/einsatz/${assignmentId}`);
+
+    assert.lengthOf(bed.mailer.sent, 1);
+    assert.equal(bed.mailer.sent[0].recepientId, "koordinator");
+    assert.include(bed.mailer.sent[0].subject, "Neue Bewerbung");
+    assert.include(bed.mailer.sent[0].subject, "Trolley Bahnhof");
+    assert.equal(bed.mailer.sent[0].replyToAddress, "gruppe@jw-public.org");
+  });
+
+  it("does not notify the applicant about their own application", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(2),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "koordinator", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinator"), 0);
+    assert.lengthOf(bed.mailer.sent, 0);
+  });
+
+  it("respects mode 'none'", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", { applicationNotifyMode: "none" });
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(1),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinator"), 0);
+    assert.lengthOf(bed.mailer.sent, 0);
+  });
+
+  it("mode 'nearOnly' skips assignments beyond the configured window", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", { applicationNotifyMode: "nearOnly", applicationNotifyDays: 7 });
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(10),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinator"), 0);
+  });
+
+  it("mode 'nearOnly' notifies for assignments inside the window", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", { applicationNotifyMode: "nearOnly", applicationNotifyDays: 7 });
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(3),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinator"), 1);
+  });
+
+  it("suppresses the email (not the in-app notification) when email opt-out is set", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinator", { notificationAsEmail: false });
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinator"],
+      start: daysFromNow(2),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinator"), 1);
+    assert.lengthOf(bed.mailer.sent, 0);
+  });
+
+  it("notifies every coordinator except the applicant", async function () {
+    const bed = new TestBed();
+    bed.addUser("koordinatorA", {});
+    bed.addUser("koordinatorB", {});
+    bed.addUser("bewerber", {});
+    const assignmentId = bed.addGroupWithAssignment({
+      coordinators: ["koordinatorA", "koordinatorB", "bewerber"],
+      start: daysFromNow(2),
+    });
+
+    await bed.notifier.notifyCoordinatorsAboutApplication(assignmentId, "bewerber", NOW);
+
+    assert.lengthOf(bed.notificationsFor("koordinatorA"), 1);
+    assert.lengthOf(bed.notificationsFor("koordinatorB"), 1);
+    assert.lengthOf(bed.notificationsFor("bewerber"), 0);
+  });
+});

--- a/src/tests/assignments/AssignmentReminder.test.ts
+++ b/src/tests/assignments/AssignmentReminder.test.ts
@@ -1,0 +1,169 @@
+import { assert } from "chai";
+
+import { AssignmentDAO } from "../../collections/lib/AssignmentsCollection";
+import { AssignmentCopyActionDAO } from "../../collections/lib/AssignmentCopyActionsCollection";
+import { GroupDAO } from "../../collections/lib/GroupCollection";
+import { NotificationDAO } from "../../collections/lib/classes/UserNotification";
+import { UserDAO } from "../../collections/lib/UserCollection";
+import { SimpleCollection } from "../../imports/interfaces/SimpleCollection";
+import { IUserMailer, IUserMailerOptions } from "../../server/mailing/interfaces/IUserMailer";
+import { IAssignmentReminder } from "../../server/assignments/classes/AssignmentReminder";
+import { buildServices } from "../../server/services";
+import { LocalCollection } from "../3rdParty/minimongo-standalone/minimongo-standalone";
+import { NullEmailSender } from "../common/NullEmailSender";
+
+const NOW = new Date("2026-07-09T10:00:00Z");
+const hoursFromNow = (h: number) => new Date(NOW.getTime() + h * 60 * 60 * 1000);
+
+class RecordingUserMailer implements IUserMailer {
+  public sent: IUserMailerOptions[] = [];
+  public async send(options: IUserMailerOptions): Promise<void> {
+    this.sent.push(options);
+  }
+}
+
+class TestBed {
+  public users = new LocalCollection<UserDAO>("users");
+  public groups = new LocalCollection<GroupDAO>("groups");
+  public assignments = new LocalCollection<AssignmentDAO>("assignments");
+  public notifications = new LocalCollection<NotificationDAO>("notifications");
+  public mailer = new RecordingUserMailer();
+  public reminder: IAssignmentReminder;
+
+  constructor() {
+    const services = buildServices(
+      {
+        assignments: this.assignments,
+        assignmentCopyActions: new LocalCollection<AssignmentCopyActionDAO>("copyActions"),
+        notifications: this.notifications,
+        users: this.users as unknown as SimpleCollection<UserDAO>,
+        groups: this.groups,
+      },
+      new NullEmailSender(),
+      { userMailer: this.mailer },
+    );
+    this.reminder = services.assignmentReminder;
+  }
+
+  addUser(id: string, profile: object = {}): string {
+    return this.users.insert({
+      _id: id,
+      profile: { first_name: id, last_name: "Test", language: "de-de", ...profile },
+    } as any);
+  }
+
+  addAssignment(options: {
+    start: Date;
+    participants?: string[];
+    state?: string;
+    remindersSentAt?: Date;
+  }): string {
+    const groupId = this.groups.insert({ name: "Testgruppe", coordinators: [] } as any);
+    return this.assignments.insert({
+      name: "Trolley Bahnhof",
+      group: groupId,
+      start: options.start,
+      end: new Date(options.start.getTime() + 2 * 60 * 60 * 1000),
+      state: options.state ?? "Online",
+      participants: (options.participants ?? []).map((user) => ({ user })),
+      applicants: [],
+      ...(options.remindersSentAt ? { remindersSentAt: options.remindersSentAt } : {}),
+    } as any);
+  }
+
+  notificationsFor(userId: string): NotificationDAO[] {
+    return this.notifications.find({ userId }).fetch();
+  }
+}
+
+describe("AssignmentReminder", function () {
+  it("reminds participants of assignments starting within the window (in-app + email)", async function () {
+    const bed = new TestBed();
+    bed.addUser("teilnehmer", { notificationAsEmail: true });
+    const assignmentId = bed.addAssignment({
+      start: hoursFromNow(12),
+      participants: ["teilnehmer"],
+    });
+
+    const count = await bed.reminder.sendDueReminders(NOW);
+
+    assert.equal(count, 1);
+    const inApp = bed.notificationsFor("teilnehmer");
+    assert.lengthOf(inApp, 1);
+    assert.equal(inApp[0].simpleData!.title, "Erinnerung an deinen Einsatz");
+    assert.include(inApp[0].simpleData!.details, "Trolley Bahnhof");
+    assert.equal(inApp[0].simpleData!.link, `/einsatz/${assignmentId}`);
+
+    assert.lengthOf(bed.mailer.sent, 1);
+    assert.include(bed.mailer.sent[0].subject, "Erinnerung");
+    assert.include(bed.mailer.sent[0].subject, "Trolley Bahnhof");
+  });
+
+  it("is idempotent: a second run does not remind again", async function () {
+    const bed = new TestBed();
+    bed.addUser("teilnehmer");
+    bed.addAssignment({ start: hoursFromNow(12), participants: ["teilnehmer"] });
+
+    await bed.reminder.sendDueReminders(NOW);
+    const secondRun = await bed.reminder.sendDueReminders(NOW);
+
+    assert.equal(secondRun, 0);
+    assert.lengthOf(bed.notificationsFor("teilnehmer"), 1);
+  });
+
+  it("stamps remindersSentAt on the assignment", async function () {
+    const bed = new TestBed();
+    bed.addUser("teilnehmer");
+    const assignmentId = bed.addAssignment({
+      start: hoursFromNow(12),
+      participants: ["teilnehmer"],
+    });
+
+    await bed.reminder.sendDueReminders(NOW);
+
+    const assignment = bed.assignments.findOne({ _id: assignmentId })!;
+    assert.instanceOf(assignment.remindersSentAt, Date);
+  });
+
+  it("skips assignments outside the window, in the past, canceled or without participants", async function () {
+    const bed = new TestBed();
+    bed.addUser("teilnehmer");
+    bed.addAssignment({ start: hoursFromNow(48), participants: ["teilnehmer"] }); // zu weit weg
+    bed.addAssignment({ start: hoursFromNow(-1), participants: ["teilnehmer"] }); // vorbei
+    bed.addAssignment({
+      start: hoursFromNow(12),
+      participants: ["teilnehmer"],
+      state: "Canceled",
+    });
+    bed.addAssignment({ start: hoursFromNow(12), participants: [] }); // niemand da
+
+    const count = await bed.reminder.sendDueReminders(NOW);
+
+    assert.equal(count, 0);
+    assert.lengthOf(bed.notificationsFor("teilnehmer"), 0);
+  });
+
+  it("suppresses the email (not the in-app notification) when email opt-out is set", async function () {
+    const bed = new TestBed();
+    bed.addUser("teilnehmer", { notificationAsEmail: false });
+    bed.addAssignment({ start: hoursFromNow(12), participants: ["teilnehmer"] });
+
+    await bed.reminder.sendDueReminders(NOW);
+
+    assert.lengthOf(bed.notificationsFor("teilnehmer"), 1);
+    assert.lengthOf(bed.mailer.sent, 0);
+  });
+
+  it("reminds every participant of a due assignment", async function () {
+    const bed = new TestBed();
+    bed.addUser("a");
+    bed.addUser("b");
+    bed.addAssignment({ start: hoursFromNow(6), participants: ["a", "b"] });
+
+    const count = await bed.reminder.sendDueReminders(NOW);
+
+    assert.equal(count, 1);
+    assert.lengthOf(bed.notificationsFor("a"), 1);
+    assert.lengthOf(bed.notificationsFor("b"), 1);
+  });
+});

--- a/src/tests/calendar/Ics.test.ts
+++ b/src/tests/calendar/Ics.test.ts
@@ -1,0 +1,111 @@
+import { assert } from "chai";
+import {
+  buildIcsCalendar,
+  escapeIcsText,
+  foldIcsLine,
+  formatIcsDateUtc,
+} from "../../imports/calendar/Ics";
+
+const NOW = new Date("2026-07-09T10:00:00Z");
+
+describe("Ics", function () {
+  describe("escapeIcsText", function () {
+    it("escapes backslash, semicolon, comma and newlines", function () {
+      assert.equal(escapeIcsText("a\\b;c,d\ne\r\nf"), "a\\\\b\\;c\\,d\\ne\\nf");
+    });
+  });
+
+  describe("formatIcsDateUtc", function () {
+    it("formats as UTC basic format with Z suffix", function () {
+      assert.equal(formatIcsDateUtc(new Date("2026-08-02T14:00:00Z")), "20260802T140000Z");
+    });
+
+    it("pads single-digit components", function () {
+      assert.equal(formatIcsDateUtc(new Date("2026-01-05T04:05:06Z")), "20260105T040506Z");
+    });
+  });
+
+  describe("foldIcsLine", function () {
+    it("keeps short lines untouched", function () {
+      assert.equal(foldIcsLine("SUMMARY:kurz"), "SUMMARY:kurz");
+    });
+
+    it("folds long lines with a leading space on continuations", function () {
+      const folded = foldIcsLine("SUMMARY:" + "x".repeat(150));
+      const lines = folded.split("\r\n");
+      assert.isAbove(lines.length, 1, "long line must be folded");
+      for (const continuation of lines.slice(1)) {
+        assert.equal(continuation[0], " ", "continuation lines start with a space");
+      }
+      // Unfolding (strip CRLF+space) must restore the original content.
+      assert.equal(folded.replace(/\r\n /g, ""), "SUMMARY:" + "x".repeat(150));
+    });
+  });
+
+  describe("buildIcsCalendar", function () {
+    it("builds a calendar frame with name and CRLF line endings", function () {
+      const ics = buildIcsCalendar({ name: "Meine Einsätze", events: [], now: NOW });
+
+      assert.match(ics, /^BEGIN:VCALENDAR\r\n/);
+      assert.include(ics, "VERSION:2.0\r\n");
+      assert.include(ics, "X-WR-CALNAME:Meine Einsätze\r\n");
+      assert.match(ics, /END:VCALENDAR\r\n$/);
+    });
+
+    it("renders events with UTC times, status and escaped fields", function () {
+      const ics = buildIcsCalendar({
+        name: "Test",
+        now: NOW,
+        events: [
+          {
+            uid: "abc123@jw-public.org",
+            summary: "Sinnflut Erding; Halle 1",
+            start: new Date("2026-08-02T14:00:00Z"),
+            end: new Date("2026-08-02T16:00:00Z"),
+            status: "CONFIRMED",
+            location: "Treffpunkt, Bahnhof",
+            description: "Zeile 1\nZeile 2",
+            url: "https://jw-public.org/einsatz/abc123",
+          },
+        ],
+      });
+
+      assert.include(ics, "BEGIN:VEVENT");
+      assert.include(ics, "UID:abc123@jw-public.org");
+      assert.include(ics, "DTSTAMP:20260709T100000Z");
+      assert.include(ics, "DTSTART:20260802T140000Z");
+      assert.include(ics, "DTEND:20260802T160000Z");
+      assert.include(ics, "SUMMARY:Sinnflut Erding\\; Halle 1");
+      assert.include(ics, "STATUS:CONFIRMED");
+      assert.include(ics, "LOCATION:Treffpunkt\\, Bahnhof");
+      assert.include(ics, "DESCRIPTION:Zeile 1\\nZeile 2");
+      assert.include(ics, "END:VEVENT");
+    });
+
+    it("renders tentative and cancelled statuses", function () {
+      const ics = buildIcsCalendar({
+        name: "Test",
+        now: NOW,
+        events: [
+          {
+            uid: "a@x",
+            summary: "Beworben",
+            start: NOW,
+            end: NOW,
+            status: "TENTATIVE",
+          },
+          {
+            uid: "b@x",
+            summary: "Abgesagt",
+            start: NOW,
+            end: NOW,
+            status: "CANCELLED",
+          },
+        ],
+      });
+
+      assert.include(ics, "STATUS:TENTATIVE");
+      assert.include(ics, "STATUS:CANCELLED");
+    });
+  });
+});


### PR DESCRIPTION
Die Top 3 der Feature-Recherche in einem PR — die drei Features mit dem größten Alltagsnutzen für Nutzer, Koordinatoren und Admins.

## 1) 🔔 Koordinator-Benachrichtigung bei neuer Bewerbung
Bisher erfuhr ein Koordinator nur durch aktives Nachschauen von neuen Bewerbungen. Jetzt benachrichtigt `applyOnAssignment` die Gruppen-Koordinatoren: **In-App immer, E-Mail** zusätzlich bei aktiviertem `notificationAsEmail` (lokalisiert de/en/fr, Reply-To = Gruppen-E-Mail).

**Self-Service pro Koordinator** (Profil → Benachrichtigungen, nur für Koordinatoren sichtbar):
- Immer benachrichtigen (Default)
- Nur wenn der Einsatz in den nächsten **X Tagen** liegt (1–60, Default 7)
- Nie

Der Bewerber selbst wird nie benachrichtigt (Selbstbewerbung eines Koordinators erzeugt kein Rauschen).

## 2) 📅 iCal-Kalenderabo
Profil → „Kalender-Abo (iCal)": persönlicher Feed-Link zum Abonnieren in Google/Apple/Outlook. Teilnahmen = `CONFIRMED`, Bewerbungen = `TENTATIVE`, Absagen = `CANCELLED` — Absagen propagieren also automatisch in den Kalender.

- `GET /api/calendar/<token>.ics` (WebApp-Handler, kein Login — der Token ist das Credential: 160 bit, nur serverseitig erzeugt, **nie publiziert**, per „Link erneuern" widerrufbar; alter Link → 404)
- Eigener minimaler ICS-Builder (`imports/calendar/Ics.ts`, RFC-5545-Escaping/-Folding, unit-getestet) statt neuer Dependency
- Sparse-Index auf `calendarToken`

## 3) ⏰ Termin-Erinnerungen (erster Scheduler der App)
`AssignmentReminder` erinnert alle Teilnehmer an Einsätze, die **in den nächsten 24h** beginnen: In-App + E-Mail (opt-in, lokalisiert). Läuft alle 15 min plus Catch-up beim Serverstart.

Idempotent über `remindersSentAt`-Stempel am Termin (claim-first; geschrieben mit `bypassCollection2`, damit weder `updatedAt` noch die `participants.when`-AutoValues angefasst werden).

## Nebenbei
Das `link`-Feld von Simple-Notifications akzeptiert jetzt relative App-Pfade — der alte `RegEx.Url` verlangte eine TLD und hätte sowohl In-App-Links als auch jede localhost-/e2e-Umgebung gebrochen.

## Validierung
- **19 neue Unit-Tests** (Notifier 7, Reminder 6, ICS 8 Assertions-Gruppen) — 128 gesamt grün
- **Neuer e2e-Spec 15**: iCal-Feed end-to-end (Erzeugen, TENTATIVE-Event, Token-Reset → alter Link 404) + Bewerbungs-Flow mit Zweit-User (Registrierung → Annahme → Bewerbung → Koordinator sieht In-App-Meldung + Mailpit-Mail)
- **Regression**: Specs 03/04/05/06/12 lokal grün
- **Reminder live verifiziert**: echter 15-min-Tick gegen lokale App — Mail „Erinnerung: Trolley … am Donnerstag, 9. Juli um 13:44" in Mailpit, In-App-Notification angelegt, `remindersSentAt` gestempelt; Termin außerhalb des Fensters (24,3h) wurde korrekt übersprungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)